### PR TITLE
feat: add IsEssential and SetEssential to TESActorBaseData

### DIFF
--- a/include/RE/T/TESActorBaseData.h
+++ b/include/RE/T/TESActorBaseData.h
@@ -1,11 +1,14 @@
 #pragma once
+
 #include "RE/A/ACTOR_BASE_DATA.h"
 #include "RE/B/BSTList.h"
 #include "RE/B/BaseFormComponent.h"
+
 namespace RE
 {
 	class FACTION_RANK;
 	class TESLevItem;
+
 	struct TESActorBaseData :
 		public BaseFormComponent
 	{

--- a/include/RE/T/TESActorBaseData.h
+++ b/include/RE/T/TESActorBaseData.h
@@ -1,14 +1,11 @@
 #pragma once
-
 #include "RE/A/ACTOR_BASE_DATA.h"
 #include "RE/B/BSTList.h"
 #include "RE/B/BaseFormComponent.h"
-
 namespace RE
 {
 	class FACTION_RANK;
 	class TESLevItem;
-
 	struct TESActorBaseData :
 		public BaseFormComponent
 	{
@@ -16,10 +13,27 @@ namespace RE
 		inline static constexpr auto RTTI = RTTI::TESActorBaseData;
 		inline static constexpr auto VTABLE = VTABLE::TESActorBaseData;
 
+		[[nodiscard]] bool IsEssential() const noexcept;
+		void               SetEssential(bool a_value) noexcept;
+
 		// members
 		ACTOR_BASE_DATA             actorData;  // 08
 		TESLevItem*                 deathItem;  // 18
 		BSSimpleList<FACTION_RANK*> factions;   // 20
 	};
 	static_assert(sizeof(TESActorBaseData) == 0x30);
+
+	inline bool TESActorBaseData::IsEssential() const noexcept
+	{
+		return actorData.actorBaseFlags.any(ACTOR_BASE_DATA::Flags::Essential);
+	}
+
+	inline void TESActorBaseData::SetEssential(bool a_value) noexcept
+	{
+		if (a_value) {
+			actorData.actorBaseFlags.set(ACTOR_BASE_DATA::Flags::Essential);
+		} else {
+			actorData.actorBaseFlags.reset(ACTOR_BASE_DATA::Flags::Essential);
+		}
+	}
 }


### PR DESCRIPTION
Adds IsEssential() and SetEssential() to TESActorBaseData.
Both are implemented inline using the existing ACTOR_BASE_DATA::Flags::Essential bit and REX::TEnumSet. No new RVAs or relocations required.
Tested against OBR 1.512.105.
I also have some validated RE data on the actor death pipeline for the same version if that is useful. Is there a Discord or preferred channel for that kind of contribution?